### PR TITLE
Split config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # FastLacellsGenerator
-Simple script to quickly generate lacells.db cell database for Local-GSM-Backend project by n76:
-
-https://github.com/n76/Local-GSM-Backend
+Simple script to quickly generate lacells.db cell database for the
+[Local-GSM-Backend project by n76](https://github.com/n76/Local-GSM-Backend).
 
 Uses both Mozilla Location Service and OpenCellID databases as source.
 
-Usage: all parameters are defined as script variables and described inside
+### Usage
+All parameters are defined as script variables and described inside. Create
+your own configuration based on the `config.sample` file: after copying it
+to `config`, adjust the values to reflect your needs.
 
-Based on lacells-creator by wvengen and n76
-https://github.com/n76/lacells-creator
+This script is based on [lacells-creator by wvengen and n76](https://github.com/n76/lacells-creator).

--- a/config.sample
+++ b/config.sample
@@ -25,7 +25,8 @@ API_KEY="dev-usr--XXXX-XXXX-XXXX-XXXXXXXXXXXX"
 # TMP_DIR: for CSV files only, use disk if you don't have enough RAM, AND
 # remember to have enough disk space in /var/tmp for sqlite temporary files
 # (about 10GB for full database)!
-# Expect the CSV files using ~350MB
+# Expect the CSV files using 4GB+ if you didn't restrict RADIO or MCC
+# (300MB+ for D-A-CH, i.e. MCC="228|232|262")
 TMP_DIR='/tmp'
 
 # KEEP_CSV: whether to keep (1) or delete (0) the CSV files after processing.

--- a/config.sample
+++ b/config.sample
@@ -29,7 +29,9 @@ API_KEY="dev-usr--XXXX-XXXX-XXXX-XXXXXXXXXXXX"
 # (300MB+ for D-A-CH, i.e. MCC="228|232|262")
 TMP_DIR='/tmp'
 
-# KEEP_CSV: whether to keep (1) or delete (0) the CSV files after processing.
+# KEEP_FILES: whether to keep (1) or delete (0) the CSV files after processing
+# (and the DB file from the previous run).
 # As you can download the OpenCellID database only once per day and API key,
-# keeping the files might be useful for testing purposes.
-KEEP_CSV=0
+# keeping the files might be useful for testing purposes. Setting this to 1
+# will keep exactly 1 backup (multiple backups are not implemented currently).
+KEEP_FILES=0

--- a/config.sample
+++ b/config.sample
@@ -1,0 +1,28 @@
+# =============================================================================
+# This is an example config file.
+# Rename it to "config" (just removing the suffix) and adjust it to your needs.
+# You can ommit values here, as defaults are defined inside the main script.
+# If the main script finds a file named "config" in the same directory where
+# it resides, it will be "sourced" and thus your settings here will overwrite
+# the defaults defined there.
+# =============================================================================
+
+# MCC: contry codes to restrict the resulting database to, separated with "|".
+# A list of available MCC values can be found e.g. at Wikipedia:
+# https://en.wikipedia.org/wiki/Mobile_country_code
+# For example "260|262" for Poland and Germany.
+# Leave dot+asterisk ".*" for all countries
+MCC="260|262"
+
+# RADIO: you can e.g. remove LTE if your phone does not support it
+RADIO="GSM|UMTS|LTE"
+
+# API_KEY: Your OpenCellID API Key. Without a valid API key, you cannot download
+# CellID data from OpenCellID. One key can download database only once per day.
+# Get your key at http://opencellid.org/
+API_KEY="dev-usr--XXXX-XXXX-XXXX-XXXXXXXXXXXX"
+
+# TMP_DIR: for CSV files only, use disk if you don't have enough RAM, AND
+# remember to have enough disk space in /var/tmp for sqlite temporary files
+# (about 10GB for full database)!
+TMP_DIR='/tmp'

--- a/config.sample
+++ b/config.sample
@@ -25,4 +25,10 @@ API_KEY="dev-usr--XXXX-XXXX-XXXX-XXXXXXXXXXXX"
 # TMP_DIR: for CSV files only, use disk if you don't have enough RAM, AND
 # remember to have enough disk space in /var/tmp for sqlite temporary files
 # (about 10GB for full database)!
+# Expect the CSV files using ~350MB
 TMP_DIR='/tmp'
+
+# KEEP_CSV: whether to keep (1) or delete (0) the CSV files after processing.
+# As you can download the OpenCellID database only once per day and API key,
+# keeping the files might be useful for testing purposes.
+KEEP_CSV=0

--- a/flg
+++ b/flg
@@ -16,6 +16,7 @@ MCC="260|262"           #contry codes separated with "|", for example "260|262".
 RADIO="GSM|UMTS|LTE"    #you can remove LTE if your phone does not support it
 API_KEY="dev-usr--XXXX-XXXX-XXXX-XXXXXXXXXXXX"  #your OCID API key, one key can download database only once per day
 TMP_DIR='/tmp'          #for CSV files only, use disk if you don't have enough RAM, AND remember to have enough disk space in /var/tmp for sqlite temporary files
+KEEP_CSV=0              #whether to keep (1) or delete (0) the CSV files after processing
 #DEFAULT_CONFIG_END
 
 #USER_CONFIG_BEGIN
@@ -39,7 +40,7 @@ wait $MO
 
 if [ -s $MOZ_FILE ] && [ -s $OCI_FILE ]; then
 
-rm lacells.db
+[[ -f lacells.db ]] && rm lacells.db
 echo "Generating database"
 
 sqlite3 lacells.db <<-SQL
@@ -82,5 +83,7 @@ else
   echo "Download error"
 fi
 
-rm $OCI_FILE
-rm $MOZ_FILE
+if [[ $KEEP_CSV -eq 0 ]]; then
+  rm $OCI_FILE
+  rm $MOZ_FILE
+fi

--- a/flg
+++ b/flg
@@ -51,7 +51,7 @@ wait $MO
 if [ -s $MOZ_FILE ] && [ -s $OCI_FILE ]; then
 
 [[ -f lacells.db ]] && {
-  if [[ $KEEP_FILES -eq 0 ]]; then
+  if [[ $KEEP_FILES -eq 0 || ! -s lacells.db ]]; then   # don't back up an empty DB
     rm lacells.db
   else
     mv lacells.db.bak

--- a/flg
+++ b/flg
@@ -11,12 +11,19 @@
 # (C)2016 Sebastian Obrusiewicz
 # sobrus@o2.pl
 
-#CONFIG_BEGIN
-MCC="260|262"		#contry codes separated with "|", for example "260|262". Leave dot+asterisk ".*" for all countries
-RADIO="GSM|UMTS|LTE"	#you can remove LTE if your phone does not support it
+#DEFAULT_CONFIG_BEGIN
+MCC="260|262"           #contry codes separated with "|", for example "260|262". Leave dot+asterisk ".*" for all countries
+RADIO="GSM|UMTS|LTE"    #you can remove LTE if your phone does not support it
 API_KEY="dev-usr--XXXX-XXXX-XXXX-XXXXXXXXXXXX"  #your OCID API key, one key can download database only once per day
-TMP_DIR='/tmp'		#for CSV files only, use disk if you don't have enough RAM, AND remember to have enough disk space in /var/tmp for sqlite temporary files (about 10GB for full database)!
-#CONFIG_END
+TMP_DIR='/tmp'          #for CSV files only, use disk if you don't have enough RAM, AND remember to have enough disk space in /var/tmp for sqlite temporary files
+#DEFAULT_CONFIG_END
+
+#USER_CONFIG_BEGIN
+BINDIR=$( dirname "$(readlink -f "$0")" ) #"
+if [[ -f "${BINDIR}/config" ]]; then
+  . "${BINDIR}/config"
+fi
+#USER_CONFIG_END
 
 NW=`date -u "+%Y-%m-%d"`
 OCI_FILE=$TMP_DIR"/ocid.csv"	#opencellid temporary file name
@@ -29,7 +36,7 @@ wget -qO- "https://d17pt8qph6ncyq.cloudfront.net/export/MLS-full-cell-export-${N
 MO=$!
 wait $OP
 wait $MO
-  
+
 if [ -s $MOZ_FILE ] && [ -s $OCI_FILE ]; then
 
 rm lacells.db

--- a/flg
+++ b/flg
@@ -16,7 +16,7 @@ MCC="260|262"           #contry codes separated with "|", for example "260|262".
 RADIO="GSM|UMTS|LTE"    #you can remove LTE if your phone does not support it
 API_KEY="dev-usr--XXXX-XXXX-XXXX-XXXXXXXXXXXX"  #your OCID API key, one key can download database only once per day
 TMP_DIR='/tmp'          #for CSV files only, use disk if you don't have enough RAM, AND remember to have enough disk space in /var/tmp for sqlite temporary files
-KEEP_CSV=0              #whether to keep (1) or delete (0) the CSV files after processing
+KEEP_FILES=0              #whether to keep (1) or delete (0) the CSV files after processing
 #DEFAULT_CONFIG_END
 
 #USER_CONFIG_BEGIN
@@ -38,9 +38,25 @@ MO=$!
 wait $OP
 wait $MO
 
+[[ ! -s $OCI_FILE && -s ${OCI_FILE}.bak ]] && { # download from OCI failed (e.g. due to download limit)
+  echo "Download from OpenCellID failed, using backup CSV"
+  mv ${OCI_FILE}.bak $OCI_FILE
+}
+[[ ! -s $MOZ_FILE && -s ${MOZ_FILE}.bak ]] && { # download from MOZ failed (for whatever reason)
+  echo "Download from Mozilla failed, using backup CSV"
+  mv ${MOZ_FILE}.bak $MOZ_FILE
+}
+
+
 if [ -s $MOZ_FILE ] && [ -s $OCI_FILE ]; then
 
-[[ -f lacells.db ]] && rm lacells.db
+[[ -f lacells.db ]] && {
+  if [[ $KEEP_FILES -eq 0 ]]; then
+    rm lacells.db
+  else
+    mv lacells.db.bak
+  fi
+}
 echo "Generating database"
 
 sqlite3 lacells.db <<-SQL
@@ -83,7 +99,10 @@ else
   echo "Download error"
 fi
 
-if [[ $KEEP_CSV -eq 0 ]]; then
+if [[ $KEEP_FILES -eq 0 ]]; then
   rm $OCI_FILE
   rm $MOZ_FILE
+else
+  mv $OCI_FILE ${OCI_FILE}.bak
+  mv $MOZ_FILE ${MOZ_FILE}.bak
 fi


### PR DESCRIPTION
Thanks for the great script! I was using the one by n76 until now, but decided to switch over :)

3 separate commits here (feel free to cherry-pick):
- 45e1507: Moved user-config out of the main script (but left defaults there). This should make updates more easy.
- 05fb7a8: `README.md` was updated to reflect that. While on it, I also applied a little formatting.
- 19c85be: as OpenCellID only permits 1 download per day, it might come in handy to have an option to keep the CSV. To make this option really useful would require:
  - renaming the files instead of simply keeping them (so the new "failing download" doesn't truncate them)
  - capturing return codes from the download and, if it failed, use the old file(s) instead
  - removing the "old copy" as soon as there's a new good one

I didn't implement the latter (yet), but just wanted to be prepared in-case-of :)
